### PR TITLE
Adjusted formCloneRemove so add button ends up in expected place in DOM

### DIFF
--- a/form-clone.js
+++ b/form-clone.js
@@ -82,6 +82,9 @@ $.fn.formCloneRemove = function(buttonCss){
 		var $parent = $(this).parent()
 			,clones = $parent.find($(this).data('el')).length-1;
 		$(this).nextAll($(this).data('el')+':first').remove();
+		if (0==$(this).nextAll($(this).data('el')).length){
+			$(this).prevAll($(this).data('el')+':first').before($(this).siblings('.form-clone-add'));
+		}
 		$(this).remove();
 		if (clones<2){
 			$parent.find('.form-clone-remove').remove();


### PR DESCRIPTION
Adjusted formCloneRemove method so if the removed element was the last one in order (and so has the clone/add button), the clone/add button is moved to its expected/usual place right before the new last element, as opposed to being left after it.
