### PR TITLE
Stopped the remove code removing remove links from inside children with clonable blocks

### DIFF
--- a/form-clone.js
+++ b/form-clone.js
@@ -76,7 +76,7 @@ $.fn.formCloneRemove=function(buttonCss){
 		$(this).prev().remove()
 		.end().remove();
 		if (clones<2){
-			$parent.find('.form-clone-remove').remove();
+			$parent.children('.form-clone-remove').remove();
 		}
 		$parent.trigger(formClone.event);
 	});


### PR DESCRIPTION
Replaced $parent.find(...) with $parent.children(...) so only match the the .form-clone-remove links at this one's level, as opposed to all lower levels too.

This change has been made due to the code removing the .form-clone-remove links for a separate form-clone instance running inside the first of the cloned elements.
