### PR TITLE
Fix cloning radio/checkbox inputs to not clear their value attributes, but uncheck them [master]

### DIFF
--- a/form-clone.js
+++ b/form-clone.js
@@ -44,9 +44,12 @@ $.fn.formClone=function(opts){
 							if ($(this).prev('.form-clone-remove').length<1){
 								$formCloneRemoveButton(el,$(this).data('buttonCss')).insertBefore($(this));
 							}
-							var $cloned=$div.clone($(this).data('all')).insertBefore($(this));
+							var $cloned=$div.clone($(this).data('all'));
+							$cloned.inputBlankArray().find('input:not([type="submit"]):not([type="radio"]):not([type="checkbox"])').val('');
+							$cloned.find('input[type="radio"], input[type="checkbox"]').prop('checked', false);
+							// do insert after un-check any radios so we don't insert checked radios and so possibly unset another already in the page
+							$cloned.insertBefore($(this));
 							$formCloneRemoveButton(el,$(this).data('buttonCss')).insertBefore($(this));
-							$cloned.inputBlankArray().find('input:not([type="submit"])').val('');
 							$(this).parent().trigger(formClone.event);
 							if (typeof $(this).data('cloneCallback')=='function'){
 								$(this).data('cloneCallback').call(null,$cloned,$div);


### PR DESCRIPTION
Altered the input value wiping code to not wipe the values for checkbox/radio inputs.
Instead, made code set their checked property to false.
In order to not uncheck radios already in the page, delayed the insert of the cloned element until after done said unchecking.