### PR TITLE
Fix cloning radio/checkbox inputs to not clear their value attributes, but uncheck them [x1.1]

### DIFF
--- a/form-clone.js
+++ b/form-clone.js
@@ -68,14 +68,17 @@ $.fn.formClone = function(options){
 					$(this).insertAfter($div);
 
 					// Pass in "all" to copy events
-					$cloned = $div.clone($(this).data('all')).insertAfter($(this));
+					$cloned = $div.clone($(this).data('all'));
 
 					$formCloneRemoveButton(el, $(this).data('buttonCss')).insertBefore($(this));
 
 					// Set data.all-values to copy values
 					if (!$(this).data('all-values')){
-						$cloned.inputBlankArray().find('input:not([type="submit"])').val('');
+						$cloned.inputBlankArray().find('input:not([type="submit"]):not([type="radio"]):not([type="checkbox"])').val('');
+						$cloned.find('input[type="radio"], input[type="checkbox"]').prop('checked', false);
 					}
+					// do insert after un-check any radios so we don't insert checked radios and so possibly unset another already in the page
+					$cloned.insertAfter($(this));
 
 					$(this).parent().trigger(formClone.event);
 

--- a/form-clone.js
+++ b/form-clone.js
@@ -74,7 +74,7 @@ $.fn.formClone = function(options){
 
 					// Set data.all-values to copy values
 					if (!$(this).data('all-values')){
-						$cloned.inputBlankArray().find('input:not([type="submit"]):not([type="radio"]):not([type="checkbox"])').val('');
+						$cloned.inputBlankArray().find('input').not('[type="submit"], [type="radio"], [type="checkbox"]').val('');
 						$cloned.find('input[type="radio"], input[type="checkbox"]').prop('checked', false);
 					}
 					// do insert after un-check any radios so we don't insert checked radios and so possibly unset another already in the page


### PR DESCRIPTION
Altered the input value wiping code to not wipe the values for checkbox/radio inputs (when not copying values too).
Instead, made code set their checked property to false (when not copying values too).
In order to not uncheck radios already in the page, delayed the insert of the cloned element until after done said unchecking.